### PR TITLE
Relax antlr4-python3 requirement.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ zip_safe = False
 include_package_data = True
 install_requires =
     sphinx>=1.8.0
-    antlr4-python3-runtime==4.7.1
+    antlr4-python3-runtime>=4.7.1,<4.10
     PyYAML
     svglib
 setup_requires =


### PR DESCRIPTION
This pull request relaxes the antlr4-python3 requirement to allow using newer releases (below 4.10).

According to https://github.com/antlr/antlr4/releases this should not be an issue, since 4.8.x and 4.9.x do not have any breaking changes to the Python 3 target.